### PR TITLE
added BSM part to sec_theory.tex (copied from full TDR).  A typo fixed.

### DIFF
--- a/ref_g-2edm.bib
+++ b/ref_g-2edm.bib
@@ -102,7 +102,7 @@
 
 @article{Semertzidis:2016kte,
       author         = "Semertzidis, Yannis K.",
-      title          = "{Spin and Beam Dynamics in the Muon (g−2)
+      title          = "{Spin and Beam Dynamics in the Muon (g-2)
                         Experiments}",
       journal        = "J. Phys. Soc. Jap.",
       volume         = "85",
@@ -178,7 +178,7 @@
       doi            = "10.3390/qubs1010011",
       SLACcitation   = ""
 }
-@article{Keshavarzi:2018mgv,
+@article{KNT18,
       author         = "Keshavarzi, Alexander and Nomura, Daisuke and Teubner,
                         Thomas",
       title          = "{Muon $g-2$ and $\alpha(M_Z^2)$: a new data-based
@@ -286,7 +286,7 @@
       author         = "Abe, M. and Murata, Y. and Iinuma, H. and Ogitsu, T. and
                         Saito, N. and Sasaki, K. and Mibe, T. and Nakayama, H.",
       title          = "{Magnetic design and method of a superconducting magnet
-                        for muon g−2 /EDM precise measurements in a cylindrical
+                        for muon g-2 /EDM precise measurements in a cylindrical
                         volume with homogeneous magnetic field}",
       journal        = "Nucl. Instrum. Meth.",
       volume         = "A890",
@@ -332,4 +332,294 @@
       pages          = "040101",
       doi            = "10.1103/PhysRevAccelBeams.19.040101",
       SLACcitation   = "%%CITATION = INSPIRE-1455960;%%"
+}
+@article{PDG,
+      author         = "Tanabashi, M. and others",
+      title          = "{Review of Particle Physics}",
+      collaboration  = "Particle Data Group",
+      journal        = "Phys. Rev.",
+      volume         = "D98",
+      year           = "2018",
+      number         = "3",
+      pages          = "030001",
+      doi            = "10.1103/PhysRevD.98.030001",
+      SLACcitation   = "%%CITATION = PHRVA,D98,030001;%%"
+}
+@article{Aoyama-etal-2017,
+      author         = "Aoyama, Tatsumi and Kinoshita, Toichiro and Nio, Makiko",
+      title          = "{Revised and Improved Value of the QED Tenth-Order
+                        Electron Anomalous Magnetic Moment}",
+      journal        = "Phys. Rev.",
+      volume         = "D97",
+      year           = "2018",
+      number         = "3",
+      pages          = "036001",
+      doi            = "10.1103/PhysRevD.97.036001",
+      eprint         = "1712.06060",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      reportNumber   = "RIKEN-QHP-345",
+      SLACcitation   = "%%CITATION = ARXIV:1712.06060;%%"
+}
+@article{Gnendiger-etal,
+      author         = "Gnendiger, C. and St{\"o}ckinger, D. and St{\"o}ckinger-Kim,
+                        H.",
+      title          = "{The electroweak contributions to $(g-2)_\mu$ after the
+                        Higgs boson mass measurement}",
+      journal        = "Phys. Rev.",
+      volume         = "D88",
+      year           = "2013",
+      pages          = "053005",
+      doi            = "10.1103/PhysRevD.88.053005",
+      eprint         = "1306.5546",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      SLACcitation   = "%%CITATION = ARXIV:1306.5546;%%"
+}
+@article{Kurz-etal-hadNNLO,
+      author         = "Kurz, Alexander and Liu, Tao and Marquard, Peter and
+                        Steinhauser, Matthias",
+      title          = "{Hadronic contribution to the muon anomalous magnetic
+                        moment to next-to-next-to-leading order}",
+      journal        = "Phys. Lett.",
+      volume         = "B734",
+      year           = "2014",
+      pages          = "144-147",
+      doi            = "10.1016/j.physletb.2014.05.043",
+      eprint         = "1403.6400",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      reportNumber   = "SFB-CPP-14-19, TTP14-009, DESY-14-038, LPN14-056",
+      SLACcitation   = "%%CITATION = ARXIV:1403.6400;%%"
+}
+@article{HLMNT,
+      author         = "Hagiwara, Kaoru and Liao, Ruofan and Martin, Alan D. and
+                        Nomura, Daisuke and Teubner, Thomas",
+      title          = "{$(g-2)_{\mu}$ and $\alpha(M_Z^2)$ re-evaluated
+                         using new precise data}",
+      journal        = "J. Phys.",
+      volume         = "G38",
+      year           = "2011",
+      pages          = "085003",
+      doi            = "10.1088/0954-3899/38/8/085003",
+      eprint         = "1105.3149",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      reportNumber   = "KEK-TH-1458, LTH-913, IPPP-11-18, DCPT-11-36, TU-883",
+      SLACcitation   = "%%CITATION = ARXIV:1105.3149;%%"
+}
+@article{DHMZ17,
+      author         = "Davier, Michel and Hoecker, Andreas and Malaescu, Bogdan
+                        and Zhang, Zhiqing",
+      title          = "{Reevaluation of the hadronic vacuum polarisation
+                        contributions to the Standard Model predictions of the
+                        muon $g-2$ and ${\alpha (m_Z^2)}$ using newest hadronic
+                        cross-section data}",
+      journal        = "Eur. Phys. J.",
+      volume         = "C77",
+      year           = "2017",
+      number         = "12",
+      pages          = "827",
+      doi            = "10.1140/epjc/s10052-017-5161-6",
+      eprint         = "1706.09436",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      SLACcitation   = "%%CITATION = ARXIV:1706.09436;%%"
+}
+@article{Colangelo-etal-NLOLbL,
+      author         = "Colangelo, Gilberto and Hoferichter, Martin and Nyffeler,
+                        Andreas and Passera, Massimo and Stoffer, Peter",
+      title          = "{Remarks on higher-order hadronic corrections to the muon
+                        g-2}",
+      journal        = "Phys. Lett.",
+      volume         = "B735",
+      year           = "2014",
+      pages          = "90-91",
+      doi            = "10.1016/j.physletb.2014.06.012",
+      eprint         = "1403.7512",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      SLACcitation   = "%%CITATION = ARXIV:1403.7512;%%"
+}
+@article{Nyffeler-LbL,
+      author         = "Nyffeler, Andreas",
+      title          = "{Precision of a data-driven estimate of hadronic
+                        light-by-light scattering in the muon $g-2$:
+                        Pseudoscalar-pole contribution}",
+      journal        = "Phys. Rev.",
+      volume         = "D94",
+      year           = "2016",
+      number         = "5",
+      pages          = "053006",
+      doi            = "10.1103/PhysRevD.94.053006",
+      eprint         = "1602.03398",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      reportNumber   = "MITP-16-018",
+      SLACcitation   = "%%CITATION = ARXIV:1602.03398;%%"
+}
+@article{Prades:2009tw,
+      author         = "Prades, Joaquim and de Rafael, Eduardo and Vainshtein,
+                        Arkady",
+      title          = "{The Hadronic Light-by-Light Scattering Contribution to
+                        the Muon and Electron Anomalous Magnetic Moments}",
+      journal        = "Adv. Ser. Direct. High Energy Phys.",
+      volume         = "20",
+      year           = "2009",
+      pages          = "303-317",
+      doi            = "10.1142/9789814271844_0009",
+      eprint         = "0901.0306",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      reportNumber   = "UG-FT-242-08, CAFPE-112-08, CPT-P092-2008,
+                        FTPI-MINN-08-41, UMN-TH-2723-08",
+      SLACcitation   = "%%CITATION = ARXIV:0901.0306;%%"
+}
+@article{Jegerlehner:2015stw,
+      author         = "Jegerlehner, Fred",
+      title          = "{Leading-order hadronic contribution to the electron and
+                        muon $g-2$}",
+      booktitle      = "{Proceedings, Workshop on Flavour changing and conserving
+                        processes 2015 (FCCP2015): Anacapri, Capri Island, Italy,
+                        September 10-12, 2015}",
+      journal        = "EPJ Web Conf.",
+      volume         = "118",
+      year           = "2016",
+      pages          = "01016",
+      doi            = "10.1051/epjconf/201611801016",
+      eprint         = "1511.04473",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      reportNumber   = "DESY-15-220, HU-EP-15-53",
+      SLACcitation   = "%%CITATION = ARXIV:1511.04473;%%"
+}
+@article{Pauk:2014rta,
+      author         = "Pauk, Vladyslav and Vanderhaeghen, Marc",
+      title          = "{Single meson contributions to the muon`s anomalous
+                        magnetic moment}",
+      journal        = "Eur. Phys. J.",
+      volume         = "C74",
+      year           = "2014",
+      number         = "8",
+      pages          = "3008",
+      doi            = "10.1140/epjc/s10052-014-3008-y",
+      eprint         = "1401.0832",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      SLACcitation   = "%%CITATION = ARXIV:1401.0832;%%"
+}
+@article{Czarnecki:2001pv,
+      author         = "Czarnecki, Andrzej and Marciano, William J.",
+      title          = "{The Muon anomalous magnetic moment: A Harbinger for 'new
+                        physics'}",
+      journal        = "Phys. Rev.",
+      volume         = "D64",
+      year           = "2001",
+      pages          = "013014",
+      doi            = "10.1103/PhysRevD.64.013014",
+      eprint         = "hep-ph/0102122",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      reportNumber   = "ALBERTA-THY-03-01, BNL-HET-01-4",
+      SLACcitation   = "%%CITATION = HEP-PH/0102122;%%"
+}
+@article{Pospelov:1991zt,
+      author         = "Pospelov, M. E. and Khriplovich, I. B.",
+      title          = "{Electric dipole moment of the W boson and the electron
+                        in the Kobayashi-Maskawa model}",
+      journal        = "Sov. J. Nucl. Phys.",
+      volume         = "53",
+      year           = "1991",
+      pages          = "638-640",
+      note           = "[Yad. Fiz.53,1030(1991)]",
+      SLACcitation   = "%%CITATION = SJNCA,53,638;%%"
+}
+@article{Booth:1993af,
+      author         = "Booth, Michael J.",
+      title          = "{The Electric dipole moment of the W and electron in the
+                        Standard Model}",
+      year           = "1993",
+      eprint         = "hep-ph/9301293",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      reportNumber   = "EFI-93-01",
+      SLACcitation   = "%%CITATION = HEP-PH/9301293;%%"
+}
+@article{Barr:1988mc,
+      author         = "Barr, Stephen M. and Marciano, William J.",
+      title          = "{ELECTRIC DIPOLE MOMENTS}",
+      journal        = "Adv. Ser. Direct. High Energy Phys.",
+      volume         = "3",
+      year           = "1989",
+      pages          = "455-499",
+      doi            = "10.1142/9789814503280_0012",
+      reportNumber   = "BNL-41939, BA-88-63",
+      SLACcitation   = "%%CITATION = 00319,3,455;%%"
+}
+@article{Bernreuther:1990jx,
+      author         = "Bernreuther, Werner and Suzuki, Mahiko",
+      title          = "{The electric dipole moment of the electron}",
+      journal        = "Rev. Mod. Phys.",
+      volume         = "63",
+      year           = "1991",
+      pages          = "313-340",
+      doi            = "10.1103/RevModPhys.63.313",
+      note           = "[Erratum: Rev. Mod. Phys.64,633(1992)]",
+      reportNumber   = "UCB-PTH-90-21, LBL-27985, HD-THEP-90-21",
+      SLACcitation   = "%%CITATION = RMPHA,63,313;%%"
+}
+@article{Pospelov:2005pr,
+      author         = "Pospelov, Maxim and Ritz, Adam",
+      title          = "{Electric dipole moments as probes of new physics}",
+      journal        = "Annals Phys.",
+      volume         = "318",
+      year           = "2005",
+      pages          = "119-169",
+      doi            = "10.1016/j.aop.2005.04.002",
+      eprint         = "hep-ph/0504231",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      SLACcitation   = "%%CITATION = HEP-PH/0504231;%%"
+}
+@article{Fukuyama:2012np,
+      author         = "Fukuyama, Takeshi",
+      title          = "{Searching for New Physics beyond the Standard Model in
+                        Electric Dipole Moment}",
+      journal        = "Int. J. Mod. Phys.",
+      volume         = "A27",
+      year           = "2012",
+      pages          = "1230015",
+      doi            = "10.1142/S0217751X12300153",
+      eprint         = "1201.4252",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      reportNumber   = "MISC-2012-03",
+      SLACcitation   = "%%CITATION = ARXIV:1201.4252;%%"
+}
+@article{Fukuyama:2015yya,
+      author         = "Fukuyama, Takeshi and Asahi, Koichiro",
+      title          = "{Filling the gaps between model predictions and their
+                        prerequisites in electric dipole moments}",
+      journal        = "Int. J. Mod. Phys.",
+      volume         = "31",
+      year           = "2016",
+      number         = "14n15",
+      pages          = "1650082",
+      doi            = "10.1142/S0217751X16500822",
+      eprint         = "1501.05291",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      SLACcitation   = "%%CITATION = ARXIV:1501.05291;%%"
+}
+@article{Kobayashi:1973fv,
+      author         = "Kobayashi, Makoto and Maskawa, Toshihide",
+      title          = "{CP Violation in the Renormalizable Theory of Weak
+                        Interaction}",
+      journal        = "Prog. Theor. Phys.",
+      volume         = "49",
+      year           = "1973",
+      pages          = "652-657",
+      doi            = "10.1143/PTP.49.652",
+      reportNumber   = "KUNS-242",
+      SLACcitation   = "%%CITATION = PTPKA,49,652;%%"
 }

--- a/sec_theory.tex
+++ b/sec_theory.tex
@@ -1,4 +1,4 @@
-\section{Theory of muon $g-2$, EDM, and muonium hyperfine splitting}
+c\section{Theory of muon $g-2$, EDM, and muonium hyperfine splitting}
 
 \def\hpz{\hphantom{0}} \def\hpzz{\hphantom{00}} \def\hph{\hphantom{-}}
 
@@ -392,6 +392,102 @@ $\Upsilon(1S-4S)$& $\hpzz0.09 \pm 0.00$  & $-$ & $\hph0.09$ \\
 Total           & $693.3 \pm 2.5$     & $693.1 \pm 3.4$ & $\hph0.2$ \\
 \hline
 \end{tabular} \end{center} \end{table*}
+
+\subsection{Muon $g-2$ in Physics beyond the SM}
+
+In general, the effect of BSM physics on the muon $g-2$
+can be described in terms of a low-energy effective Lagrangian
+if the scale of the BSM physics is high enough compared to the
+muon mass.   After integrating out heavy fields in the
+BSM physics, we obtain the term below in the effective Lagrangian:
+%
+\begin{align}
+ {\mathcal L} = \frac{e}{4 m_\mu}
+ \frac{m_\mu^2}{\Lambda_{\text{NP}}^2} 
+ \overline{\psi_L} ~ \sigma_{\mu\nu} F^{\mu\nu} \psi_R + {\text{h.\ c.\ }},
+\label{eq:effL_g-2}
+\end{align}
+%
+where $\psi$ is the field for the muon and
+$\Lambda_{\text{NP}}$ is the scale of the new physics\footnote{
+The $\Lambda_{\text{NP}}$-dependence of Eq.~(\ref{eq:effL_g-2})
+is determined from the following discussion.  The
+operators appearing on the right-hand side of Eq.~(\ref{eq:effL_g-2})
+are chirality-flipping operators which connect the right-handed
+fermion to the left-handed one, and hence the couplings in
+front of the operators must be something which flips the chirality.
+Since the muon mass flips the chirality, in 
+Eq.~(\ref{eq:effL_g-2}) we naively assume that the operators
+are multiplied by one factor of $m_\mu$.  To match the dimension,
+we further need to multiply the operators by a quantity which
+has a mass dimension of $[\text{mass}]^{-2}$.  
+We take this as $\Lambda^{-2}_{\text{NP}}$.
+
+Of course this is just a naive discussion, and the chirality
+may be flipped by another chirality-flipping parameter generated
+by new physics.  In such a case, the new physics contribution 
+to $a_\mu$ may be proportional to $1/\Lambda_{\text{NP}}$,
+not $1/\Lambda^2_{\text{NP}}$.  See e.g.\ Ref.~\cite{Czarnecki:2001pv}
+for the models in which the latter possibility is realized.}.
+In the non-relativistic limit, the effective interaction
+above is equivalent to the contribution $\delta V_{\text{NP}}$
+to the potential below
+%
+\begin{align}
+ \delta V_{\text{NP}} = - \vec{\mu}_{\text{NP}} \cdot \vec{B}~,
+\end{align}
+%
+where $\vec{\mu}_{\text{NP}}$ is the new physics
+contribution to the magnetic moment of the muon and
+$\vec{B}$ the magnetic field,
+and hence the operator in Eq.~(\ref{eq:effL_g-2}) is
+responsible for the muon $g-2$.
+The contribution $a_\mu(\text{NP})$ to the muon $g-2$ from
+the new physics is related to $\Lambda_{\text{NP}}$ as
+%
+\begin{align}
+ a_\mu(\text{NP}) =  \frac{m_\mu^2}{\Lambda_{\text{NP}}^2} ~.
+\end{align}
+%
+The scale $\Lambda_{\text{NP}}$ can be determined 
+by assuming that the above contribution is responsible
+for the non-zero value of $\delta a_\mu$.  For example,
+if we take the evaluation of HLMNT11
+in Eq.~(\ref{eq:chap2_tmp11}), we obtain
+%
+\begin{align}
+ \Lambda_{\text{NP}} = 1.8 - 2.6 ~ (\text{TeV})~.
+\end{align}
+%
+Note that this is a very rough estimate.
+There are lots of BSM models which give contribution
+to $a_\mu$.  
+The most typical and well-studied model is the
+supersymmetric (SUSY) models.  
+To get a rough idea of the size of the SUSY contribution,
+let us take the minimal SUSY SM as an example. 
+In the MSSM, the leading SUSY contribution comes from
+one-loop chargino-sneutrino and the neutralino-smuon diagrams.  
+If we assume that all the SUSY particles have the
+common mass $\tilde{m}$, the one-loop SUSY contribution
+$a_\mu(\text{SUSY})$ is roughly given as~\cite{Czarnecki:2001pv}
+%
+\begin{align}
+ a_\mu(\text{SUSY}) = (\text{sgn} \mu)  \times 13 \times 10^{-10}
+\times \left( \frac{100 ~\text{GeV}}{\tilde{m}}\right)^2 \tan\beta~,
+\end{align}
+%
+where $\tan\beta = \langle H_u \rangle/ \langle H_d \rangle$ 
+is the ratio of the vacuum expectation values of the two Higgs
+fields in the MSSM.  Note that e.g.\ for 
+$(\tilde{m}, \tan\beta, \text{sgn}\mu) 
+= ({\mathcal O}(300) ~\text{GeV}, {\mathcal O}(10), +1)$,
+the size of $a_\mu(\text{SUSY})$ is precisely the right
+range to explain the deviation, Eq.~(\ref{eq:chap2_tmp11}).  
+The muon $g-2$ therefore gives a very important probe
+of new physics, and it is very important to more firmly 
+establish the currently observed deviation in the muon $g-2$.
+
 
 
 

--- a/sec_theory.tex
+++ b/sec_theory.tex
@@ -11,7 +11,7 @@ hadronic contributions:
 \begin{align}
    a_\mu(\text{SM})
 &=   a_\mu(\text{QED}) +  a_\mu(\text{EW})
-   + a_\mu(\text{hadronic})~,
+   + a_\mu(\text{hadronic})~.
 \end{align}
 %
 The QED and EW contributions are perturbatively calculable,
@@ -65,7 +65,7 @@ historically important references behind them to list in the table.}
    \phantom{$-$}11~659~182.05~(3.56)   & Ref.~\cite{KNT18} \\
 %\hline
   experimental value, $a_\mu(\text{exp})$
- & \phantom{$-$}11~659~209.1 (6.3) & Refs.~\cite{Bennett:2004pv,PDG17} \\
+ & \phantom{$-$}11~659~209.1 (6.3) & Refs.~\cite{Bennett:2006fi,PDG} \\
 \hline \hline
  difference, $\Delta a_\mu$ 
  ($\equiv a_\mu(\text{exp}) - a_\mu(\text{SM})$) & 
@@ -76,7 +76,7 @@ historically important references behind them to list in the table.}
 
 
 
-The QED contribution is known to 5-loop~\cite{AKN17}. 
+The QED contribution is known to 5-loop~\cite{Aoyama-etal-2017}. 
 The latest value is
 %
 \begin{align}
@@ -98,7 +98,7 @@ the QED contribution does not seem to pose any problem.
 
 The EW contribution is calculated up to and including
 2-loop.  The most up-to-date value, which includes 
-the Higgs boson mass, reads~\cite{Gnendiger}:
+the Higgs boson mass, reads~\cite{Gnendiger-etal}:
 %
 \begin{align}
  a_\mu(\text{EW}) &=  (15.36 \pm 0.10) \times 10^{-10} ~.
@@ -170,8 +170,8 @@ a_\mu^{\text{had, LbL}}= (9.8 \pm 2.6) \times 10^{-10}~.
 \end{align}
 %
 This value has been obtained from the ``Glasgow consensus''
-value~\cite{} with a correction from a recent reevaluation
-of the axial vector particle exchange~\cite{}.
+value~\cite{Prades:2009tw} with a correction from a recent reevaluation
+of the axial vector particle exchange~\cite{Jegerlehner:2015stw,Pauk:2014rta}.
 The value of $a_\mu^{\text{had, NLO LbL}}$ is computed
 in Ref.~\cite{Colangelo-etal-NLOLbL}:
 %
@@ -335,7 +335,7 @@ experimental data.
 
 \begin{table*} 
 \caption{Differences between the KNT18 analysis~\cite{KNT18} 
-and the DHMZ17 analysis~\cite{DHMNZ17}, extracted from 
+and the DHMZ17 analysis~\cite{DHMZ17}, extracted from 
 Table 5 of Ref.~\cite{KNT18}. 
 Similarly to Table~\ref{table:contributions}, the numbers
 from the region $\sqrt{s} \leq 2$ GeV

--- a/sec_theory.tex
+++ b/sec_theory.tex
@@ -1,4 +1,4 @@
-c\section{Theory of muon $g-2$, EDM, and muonium hyperfine splitting}
+\section{Theory of muon $g-2$, EDM, and muonium hyperfine splitting}
 
 \def\hpz{\hphantom{0}} \def\hpzz{\hphantom{00}} \def\hph{\hphantom{-}}
 


### PR DESCRIPTION
added BSM part to sec_theory.tex (copied from full TDR).  Also, a typo fixed.