### PR TITLE
various minor fixes/updates.  First draft of the summary section written

### DIFF
--- a/frontiers.tex
+++ b/frontiers.tex
@@ -27,7 +27,7 @@
 
 
 \def\keyFont{\fontsize{8}{11}\helveticabold }
-\def\firstAuthorLast{D.~Nomura, T.~Mibe, K.~Simomura} %use et al only if is more than 1 author
+\def\firstAuthorLast{D.~Nomura, T.~Mibe, K.~Shimomura} %use et al only if is more than 1 author
 \def\Authors{Daisuke Nomura\,$^{1}$, Tsutomu Mibe\,$^{1,*}$ and Koichiro Shimomura\,$^{2}$}
 % Affiliations should be keyed to the author's name with superscript numbers and be listed as follows: Laboratory, Institute, Department, Organization, City, State abbreviation (USA, Canada, Australia), and Country (without detailed address information such as city zip codes or street names).
 % If one of the authors has a change of address, list the new address below the correspondence details using a superscript symbol and use the same symbol to indicate the author in the author list.

--- a/ref_g-2edm.bib
+++ b/ref_g-2edm.bib
@@ -957,5 +957,14 @@ with SiPM readout for muon spin spectrometers}",
          ISSN={1051-8223},
          month={June}
 }
-
-
+@article{Ishikawa:2018rlv,
+      author         = "Ishikawa, Tadashi and Nakazawa, Nobuya and Yasui,
+                        Yoshiaki",
+      title          = "{Numerical calculation of the full two-loop electroweak
+                        corrections to muon ($g$-2)}",
+      year           = "2018",
+      eprint         = "1810.13445",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      SLACcitation   = "%%CITATION = ARXIV:1810.13445;%%"
+}

--- a/sec_intro.tex
+++ b/sec_intro.tex
@@ -46,7 +46,7 @@ This number should be compared with the current experimental
 value,
 %
 \begin{align}
- d_\mu(\text{exp}) = (-0.1 \pm 0.9) \times 10^{-19} \ e \text{ cm} ~,
+ d_\mu(\text{exp}) = (0.0 \pm 0.9) \times 10^{-19} \ e \text{ cm} ~,
 \end{align}
 %
 and the aimed sensitivity of the J-PARC $g-2$/EDM
@@ -65,11 +65,22 @@ splitting can be used to extract the muon-proton magnetic
 moment ratio, $\mu_\mu/\mu_p$.  As discussed later in this review,
 the value of this ratio is used as an input parameter to obtain
 the value Eq.~(\ref{eq:a_mu_exp}) in the BNL E821 experiment.  
+More explicitly, the BNL paper obtains the value of $a_\mu$
+from the equation,
+%
+\begin{align}
+ a_\mu(\text{exp}) =
+  \frac{\omega_a/\omega_p}{\mu_\mu/\mu_p - \omega_a/\omega_p} ~, 
+\end{align}
+%
+where $\omega_a$ is the muon anomalous spin precession frequency,
+while $\omega_p$ is the free proton NMR frequency.
 Currently, the value obtained from an indirect measurement of 
 $\mu_\mu/\mu_p$ is used, assuming that the SM is the correct
-theory at low energies.  However, it is more desirable to directly
-measure $\mu_\mu/\mu_p$ without assuming the SM since we are 
-trying to search for physics beyond the SM.  One of the main
+theory at low energies.  However, it is more desirable to use
+a directly measured value of $\mu_\mu/\mu_p$ obtained without
+assuming the SM since we are trying to search for physics
+beyond the SM.  One of the main
 purposes of the MuSEUM experiment is to provide such a direct
 measurement with the highest precision ever, as discussed later.  
 

--- a/sec_museum.tex
+++ b/sec_museum.tex
@@ -282,7 +282,7 @@ The long-term stability was measured at 3 ppb/hour over a 10
 days period.  The helium evaporation rate was 3 L/day.  All
 this fulfills our design values.
 
-For the precise magnetic field monitoring,a continuous wave
+For the precise magnetic field monitoring, a continuous wave
 NMR (CW-NMR) system with a RF pickup coil is being developed
 for both $g-2$/EDM and MuSEUM experiments at J-PARC.  A field
 mapping probe with 24 RF pickup coils is being constructed

--- a/sec_summary.tex
+++ b/sec_summary.tex
@@ -1,1 +1,80 @@
 \section{Summary}
+
+In this article, we have given a brief overview of the
+current status of theory and experiments on the muon $g-2$,
+muon EDM and muonium hyperfine splitting, and a prospect
+expected in the near future.  In particular, we have put
+some emphasis on the activities in J-PARC.
+
+Currently, there is a more-than 3 $\sigma$ discrepancy
+between the experimental value of the muon $g-2$ and the
+SM prediction for it.  The current experimental precision
+of the muon $g-2$ is 0.5 ppm, while the uncertainty of
+the SM prediction for it is 0.3 ppm.  There are two
+experiments which will improve the experimental value:
+one is at J-PARC, and the other at Fermilab.  Both
+experiments aim to reduce the uncertainty by a factor
+of 4, compared to the current value.  Although the Fermilab
+experiment uses the same technique as that used in the BNL
+experiment, the J-PARC experiment relies on a completely
+different method, and hence is an independent check of the
+BNL and Fermilab experiments.  
+
+The SM prediction for the muon $g-2$ will also be improved
+by new data of $e^+ e^- \to \pi^+\pi^-$ from Belle II, CMD-3
+and SND.  Improvements of the evaluation of the light-by-light
+contribution and the lattice calculations can also be expected.
+
+Observation of a non-vanishing muon EDM immediately means
+a signal of new physics beyond the SM.  In the J-PARC
+experiment, it is expected to improve the experimental
+upper bound of the muon EDM by a factor of 60.
+
+The muonium HFS is an indispensable input parameter to
+derive an experimental value of $a_\mu$ from the 
+anomalous spin precession frequency $\omega_a$.
+Currently, the indirectly observed value of the 
+magnetic moment ratio $\mu_\mu/\mu_p$ is used in the
+BNL paper, but ultimately this should be replaced by
+a directly measured value of $\mu_\mu/\mu_p$.  In the
+on-going experiment MuSEUM, it is possible to obtain
+the directly measured value of $\mu_\mu/\mu_p$ to the
+accuracy of x.xx ppm, which makes it possible to
+replace the current indirectly measured value of
+$\mu_\mu/\mu_p$ in the near future.  This will put the
+status of the reported muon $g-2$ anomaly on a firmer
+ground. 
+
+All of the above quantities serve as useful probes of new
+physics beyond the SM.  In particular, since there is a
+more than 3 $\sigma$ anomaly reported on the muon $g-2$,
+it is extremely important to study the muon sector very 
+carefully.  Since no new physics beyond the
+SM has been observed at experiments at high energies 
+like the LHC, the importance of the precision physics 
+in the muon sector has become higher than ever.  We hope that
+these efforts will shed light on the existence of physics
+beyond the SM.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+
+

--- a/sec_theory.tex
+++ b/sec_theory.tex
@@ -108,7 +108,29 @@ the Higgs boson mass, reads~\cite{Gnendiger-etal}:
 Similarly to the QED contribution, the uncertainty of the EW
 contribution is small enough.  Since this is a perturbatively
 calculable quantity, this contribution is already understood
-very well.
+very well.\footnote{
+Recently, a new evaluation of the 2-loop EW contribution
+appeared \cite{Ishikawa:2018rlv}, which claims
+%
+\begin{align}
+ a_\mu(\text{EM, 2-loop}) = (-3.86 \pm 0.01) \times 10^{-10}~,
+\label{eq:Ishikawa:2018rlv}
+\end{align}
+%
+which has a slightly smaller mean value with
+a much smaller uncertainty compared to the corresponding value
+in Ref.~\cite{Gnendiger-etal},
+%
+\begin{align}
+ a_\mu(\text{EM, 2-loop}) = (-4.12 \pm 0.10) \times 10^{-10}~.
+\label{eq:Gnendiger-etal-2loop}
+\end{align}
+%
+The calculation of Ref.~\cite{eq:Ishikawa:2018rlv} may be solid,
+but the uncertainty in Eq.~(\ref{eq:Ishikawa:2018rlv})
+does not seem to include the hadronic uncertainty which is
+a dominant source of error in Eq.~(\ref{eq:Gnendiger-etal-2loop}).}
+
 
 It is the hadronic contribution which is most intractable.
 The hadronic contribution can be written as the sum of a 
@@ -551,7 +573,7 @@ This is far smaller than the current experimental
 upper bound on the muon EDM $d_\mu(\text{exp})$~\cite{Bennett:2008dy},
 %
 \begin{align}
- d_\mu(\text{exp}) = (-0.1\pm 0.9) \times 10^{-19}  e {\text{cm}}~,
+ d_\mu(\text{exp}) = (0.0\pm 0.9) \times 10^{-19}  e {\text{cm}}~,
 \end{align}
 %
 and also than the aimed sensitivity of the J-PARC 


### PR DESCRIPTION
- 1st draft of the summary section written.
- Fixed the exp. mean value of d_mu (-0.1 --> 0.0) in the intro and theory sections.
- Added a mention to the new 2-loop EW contribution (from the Minami-tateya group) in the theory section, and added the reference to the bib file. 
- A typo fixed in the museum section.
- A typo fixed in the main file, frontiers.tex (Simomura --> Shimomura).
